### PR TITLE
Add conditional distinct() optimization in NodeSet

### DIFF
--- a/.claude/.lsp.json
+++ b/.claude/.lsp.json
@@ -1,0 +1,9 @@
+{
+  "python": {
+    "command": "basedpyright-langserver",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".py": "python"
+    }
+  }
+}

--- a/apibase/graphql/fields.py
+++ b/apibase/graphql/fields.py
@@ -1,8 +1,96 @@
 # https://docs.graphene-python.org/projects/django/en/latest/queries/
+from django_filters.utils import get_field_parts
 from graphene_django.filter import DjangoFilterConnectionField
 
 from .. import filters, utils
 from .connections import FilteringConnection
+
+
+def _filter_needs_distinct(filter_field, model):
+    """Check if a filter requires distinct() based on explicit flag or M2M/reverse FK.
+
+    Args:
+        filter_field: A django_filters filter instance
+        model: The Django model class
+
+    Returns:
+        True if the filter needs distinct(), False otherwise
+    """
+    # Layer 1: Explicit distinct flag
+    if getattr(filter_field, "distinct", False):
+        return True
+
+    # Layer 2: Analyze field path for M2M or reverse FK relationships
+    field_name = getattr(filter_field, "field_name", None)
+    if field_name:
+        try:
+            field_parts = get_field_parts(model, field_name)
+            for field in field_parts:
+                if getattr(field, "many_to_many", False):
+                    return True
+                if getattr(field, "one_to_many", False):
+                    return True
+        except Exception:
+            pass  # Field path analysis failed, continue to next layer
+
+    return False
+
+
+def _queryset_has_duplicating_joins(qs):
+    """Fallback: Check QuerySet's alias_map for JOINs that could cause duplicates.
+
+    Args:
+        qs: A Django QuerySet
+
+    Returns:
+        True if the QuerySet has JOINs that could cause duplicate rows
+    """
+    try:
+        from django.db.models.sql.datastructures import Join
+
+        for _alias, join_info in qs.query.alias_map.items():
+            if isinstance(join_info, Join) and join_info.join_field:
+                join_field = join_info.join_field
+                if getattr(join_field, "many_to_many", False):
+                    return True
+                if getattr(join_field, "one_to_many", False):
+                    return True
+        return False
+    except Exception:
+        return True  # Conservative fallback on error
+
+
+def _needs_distinct(qs, args, filterset_class):
+    """Determine if queryset needs distinct() applied.
+
+    Args:
+        qs: A Django QuerySet
+        args: The GraphQL query arguments
+        filterset_class: The FilterSet class (or None)
+
+    Returns:
+        True if distinct() should be applied, False otherwise
+    """
+    if not filterset_class:
+        return False
+
+    model = filterset_class._meta.model
+    base_filters = filterset_class.base_filters
+
+    # Find which filters are actually applied
+    applied_filter_names = set(args.keys()) & set(base_filters.keys())
+
+    if not applied_filter_names:
+        return False  # No filters applied
+
+    # Check each applied filter
+    for filter_name in applied_filter_names:
+        filter_field = base_filters[filter_name]
+        if _filter_needs_distinct(filter_field, model):
+            return True
+
+    # Fallback: Check QuerySet JOINs
+    return _queryset_has_duplicating_joins(qs)
 
 
 class NodeSet(DjangoFilterConnectionField):
@@ -48,5 +136,9 @@ class NodeSet(DjangoFilterConnectionField):
     @classmethod
     def resolve_queryset(cls, connection, iterable, info, args, filtering_args, filterset_class):
         qs = super().resolve_queryset(connection, iterable, info, args, filtering_args, filterset_class)
-        # duplicated result when related models are filtered
-        return qs.distinct()
+
+        # Apply distinct() only when needed (M2M, reverse FK, or explicit distinct=True)
+        if _needs_distinct(qs, args, filterset_class):
+            return qs.distinct()
+
+        return qs

--- a/apibase/graphql/tests/conftest.py
+++ b/apibase/graphql/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest configuration for graphql tests."""
+
+import django
+from django.conf import settings
+
+
+def pytest_configure():
+    """Configure Django settings for tests."""
+    if not settings.configured:
+        settings.configure(
+            DEBUG=True,
+            DATABASES={
+                "default": {
+                    "ENGINE": "django.db.backends.sqlite3",
+                    "NAME": ":memory:",
+                }
+            },
+            INSTALLED_APPS=[
+                "django.contrib.contenttypes",
+                "django.contrib.auth",
+            ],
+            DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+        )
+        django.setup()

--- a/apibase/graphql/tests/test_distinct.py
+++ b/apibase/graphql/tests/test_distinct.py
@@ -1,0 +1,376 @@
+"""
+Tests for conditional distinct() in NodeSet.resolve_queryset().
+
+TDD: These tests are written BEFORE implementation.
+The helper functions being tested:
+- _filter_needs_distinct(filter_field, model)
+- _queryset_has_duplicating_joins(qs)
+- _needs_distinct(qs, args, filterset_class)
+"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+
+def create_mock_filter(field_name, distinct=False, method=None):
+    """Create a mock filter field."""
+    filter_field = MagicMock()
+    filter_field.field_name = field_name
+    filter_field.distinct = distinct
+    filter_field.method = method
+    return filter_field
+
+
+def create_mock_field(many_to_many=False, one_to_many=False):
+    """Create a mock Django field."""
+    field = MagicMock()
+    field.many_to_many = many_to_many
+    field.one_to_many = one_to_many
+    return field
+
+
+def create_mock_filterset_class(base_filters, model=None):
+    """Create a mock FilterSet class."""
+    filterset_class = MagicMock()
+    filterset_class.base_filters = base_filters
+    filterset_class._meta = MagicMock()
+    filterset_class._meta.model = model
+    return filterset_class
+
+
+class TestFilterNeedsDistinct:
+    """Tests for _filter_needs_distinct() helper function."""
+
+    def test_explicit_distinct_true_returns_true(self):
+        """Filter with distinct=True should return True."""
+        from apibase.graphql.fields import _filter_needs_distinct
+
+        filter_field = create_mock_filter("title", distinct=True)
+        model = MagicMock()
+
+        result = _filter_needs_distinct(filter_field, model)
+        assert result is True
+
+    def test_simple_field_returns_false(self):
+        """Simple field filter should return False."""
+        from apibase.graphql.fields import _filter_needs_distinct
+
+        filter_field = create_mock_filter("is_active", distinct=False)
+        model = MagicMock()
+
+        # Mock get_field_parts to return a simple field
+        simple_field = create_mock_field(many_to_many=False, one_to_many=False)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "apibase.graphql.fields.get_field_parts", lambda m, f: [simple_field] if f == "is_active" else []
+            )
+            result = _filter_needs_distinct(filter_field, model)
+
+        assert result is False
+
+    def test_fk_field_returns_false(self):
+        """FK field filter should return False."""
+        from apibase.graphql.fields import _filter_needs_distinct
+
+        filter_field = create_mock_filter("author_id", distinct=False)
+        model = MagicMock()
+
+        # FK field - not many_to_many, not one_to_many
+        fk_field = create_mock_field(many_to_many=False, one_to_many=False)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("apibase.graphql.fields.get_field_parts", lambda m, f: [fk_field])
+            result = _filter_needs_distinct(filter_field, model)
+
+        assert result is False
+
+    def test_m2m_field_returns_true(self):
+        """M2M field filter should return True."""
+        from apibase.graphql.fields import _filter_needs_distinct
+
+        filter_field = create_mock_filter("tags__name", distinct=False)
+        model = MagicMock()
+
+        # M2M field
+        m2m_field = create_mock_field(many_to_many=True, one_to_many=False)
+        name_field = create_mock_field(many_to_many=False, one_to_many=False)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("apibase.graphql.fields.get_field_parts", lambda m, f: [m2m_field, name_field])
+            result = _filter_needs_distinct(filter_field, model)
+
+        assert result is True
+
+    def test_reverse_fk_field_returns_true(self):
+        """Reverse FK field filter (one_to_many) should return True."""
+        from apibase.graphql.fields import _filter_needs_distinct
+
+        filter_field = create_mock_filter("comments__text", distinct=False)
+        model = MagicMock()
+
+        # Reverse FK field (one_to_many)
+        reverse_fk_field = create_mock_field(many_to_many=False, one_to_many=True)
+        text_field = create_mock_field(many_to_many=False, one_to_many=False)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("apibase.graphql.fields.get_field_parts", lambda m, f: [reverse_fk_field, text_field])
+            result = _filter_needs_distinct(filter_field, model)
+
+        assert result is True
+
+    def test_method_filter_without_distinct_returns_false(self):
+        """Method filter without distinct=True should return False."""
+        from apibase.graphql.fields import _filter_needs_distinct
+
+        filter_field = create_mock_filter("custom", distinct=False, method="filter_custom")
+        model = MagicMock()
+
+        # Method filters don't have valid field_name for get_field_parts
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("apibase.graphql.fields.get_field_parts", lambda m, f: [])
+            result = _filter_needs_distinct(filter_field, model)
+
+        assert result is False
+
+    def test_method_filter_with_distinct_returns_true(self):
+        """Method filter with distinct=True should return True."""
+        from apibase.graphql.fields import _filter_needs_distinct
+
+        filter_field = create_mock_filter("custom", distinct=True, method="filter_custom")
+        model = MagicMock()
+
+        # Distinct=True takes precedence, no need to check field parts
+        result = _filter_needs_distinct(filter_field, model)
+        assert result is True
+
+    def test_get_field_parts_exception_returns_false(self):
+        """When get_field_parts raises, should return False (continue to next layer)."""
+        from apibase.graphql.fields import _filter_needs_distinct
+
+        filter_field = create_mock_filter("invalid_field", distinct=False)
+        model = MagicMock()
+
+        with pytest.MonkeyPatch.context() as mp:
+
+            def raise_error(m, f):
+                raise Exception("Field not found")
+
+            mp.setattr("apibase.graphql.fields.get_field_parts", raise_error)
+            result = _filter_needs_distinct(filter_field, model)
+
+        assert result is False
+
+
+class TestQuerysetHasDuplicatingJoins:
+    """Tests for _queryset_has_duplicating_joins() fallback function."""
+
+    def test_empty_alias_map_returns_false(self):
+        """QuerySet with no joins should return False."""
+        from apibase.graphql.fields import _queryset_has_duplicating_joins
+
+        qs = MagicMock()
+        qs.query.alias_map = {}
+
+        result = _queryset_has_duplicating_joins(qs)
+        assert result is False
+
+    def test_m2m_join_returns_true(self):
+        """QuerySet with M2M join should return True."""
+        from django.db.models.sql.datastructures import Join
+
+        from apibase.graphql.fields import _queryset_has_duplicating_joins
+
+        # Create a proper Join-like object using the actual Join class signature
+        # We need to create a mock that passes isinstance(obj, Join)
+        join_field = create_mock_field(many_to_many=True, one_to_many=False)
+
+        # Create an actual Join instance (or close enough for isinstance check)
+        # The function checks isinstance(join_info, Join), so we use a real Join
+        # But we need to mock the join_field attribute
+        class MockJoin(Join):
+            """Mock Join that overrides join_field."""
+
+            def __init__(self, join_field):
+                self._join_field = join_field
+
+            @property
+            def join_field(self):
+                return self._join_field
+
+        mock_join = MockJoin(join_field)
+
+        qs = MagicMock()
+        qs.query.alias_map = {"tags": mock_join}
+
+        result = _queryset_has_duplicating_joins(qs)
+        assert result is True
+
+    def test_exception_returns_true(self):
+        """On error, should conservatively return True."""
+        from apibase.graphql.fields import _queryset_has_duplicating_joins
+
+        qs = MagicMock()
+        type(qs.query).alias_map = PropertyMock(side_effect=Exception("test error"))
+
+        result = _queryset_has_duplicating_joins(qs)
+        assert result is True
+
+
+class TestNeedsDistinct:
+    """Tests for _needs_distinct() composite function."""
+
+    def test_no_filterset_class_returns_false(self):
+        """When filterset_class is None, return False."""
+        from apibase.graphql.fields import _needs_distinct
+
+        qs = MagicMock()
+        result = _needs_distinct(qs, args={"is_active": True}, filterset_class=None)
+        assert result is False
+
+    def test_no_filters_applied_returns_false(self):
+        """When no filters are applied (empty args), return False."""
+        from apibase.graphql.fields import _needs_distinct
+
+        qs = MagicMock()
+        filterset_class = create_mock_filterset_class(
+            base_filters={"is_active": create_mock_filter("is_active")}, model=MagicMock()
+        )
+
+        result = _needs_distinct(qs, args={}, filterset_class=filterset_class)
+        assert result is False
+
+    def test_filter_arg_not_in_base_filters_returns_false(self):
+        """When filter arg doesn't match any base_filter, return False."""
+        from apibase.graphql.fields import _needs_distinct
+
+        qs = MagicMock()
+        qs.query.alias_map = {}
+        filterset_class = create_mock_filterset_class(
+            base_filters={"is_active": create_mock_filter("is_active")}, model=MagicMock()
+        )
+
+        # 'unknown' is not in base_filters
+        result = _needs_distinct(qs, args={"unknown": True}, filterset_class=filterset_class)
+        assert result is False
+
+    def test_simple_filter_returns_false(self):
+        """Simple filter (is_active) should return False."""
+        from apibase.graphql.fields import _needs_distinct
+
+        qs = MagicMock()
+        qs.query.alias_map = {}
+
+        simple_filter = create_mock_filter("is_active", distinct=False)
+        filterset_class = create_mock_filterset_class(base_filters={"is_active": simple_filter}, model=MagicMock())
+
+        # Mock get_field_parts to return simple field
+        simple_field = create_mock_field(many_to_many=False, one_to_many=False)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("apibase.graphql.fields.get_field_parts", lambda m, f: [simple_field])
+            result = _needs_distinct(qs, args={"is_active": True}, filterset_class=filterset_class)
+
+        assert result is False
+
+    def test_m2m_filter_returns_true(self):
+        """M2M filter should return True."""
+        from apibase.graphql.fields import _needs_distinct
+
+        qs = MagicMock()
+        qs.query.alias_map = {}
+
+        m2m_filter = create_mock_filter("tags__name", distinct=False)
+        filterset_class = create_mock_filterset_class(base_filters={"tags__name": m2m_filter}, model=MagicMock())
+
+        # Mock get_field_parts to return M2M field
+        m2m_field = create_mock_field(many_to_many=True, one_to_many=False)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("apibase.graphql.fields.get_field_parts", lambda m, f: [m2m_field])
+            result = _needs_distinct(qs, args={"tags__name": "python"}, filterset_class=filterset_class)
+
+        assert result is True
+
+    def test_multiple_filters_one_needs_distinct_returns_true(self):
+        """If any filter needs distinct, return True."""
+        from apibase.graphql.fields import _needs_distinct
+
+        qs = MagicMock()
+        qs.query.alias_map = {}
+
+        simple_filter = create_mock_filter("is_active", distinct=False)
+        m2m_filter = create_mock_filter("tags__name", distinct=False)
+        filterset_class = create_mock_filterset_class(
+            base_filters={"is_active": simple_filter, "tags__name": m2m_filter}, model=MagicMock()
+        )
+
+        # Mock get_field_parts
+        simple_field = create_mock_field(many_to_many=False, one_to_many=False)
+        m2m_field = create_mock_field(many_to_many=True, one_to_many=False)
+
+        with pytest.MonkeyPatch.context() as mp:
+
+            def get_parts(m, f):
+                if f == "is_active":
+                    return [simple_field]
+                elif f == "tags__name":
+                    return [m2m_field]
+                return []
+
+            mp.setattr("apibase.graphql.fields.get_field_parts", get_parts)
+            result = _needs_distinct(
+                qs, args={"is_active": True, "tags__name": "python"}, filterset_class=filterset_class
+            )
+
+        assert result is True
+
+    def test_explicit_distinct_filter_returns_true(self):
+        """Filter with explicit distinct=True should return True."""
+        from apibase.graphql.fields import _needs_distinct
+
+        qs = MagicMock()
+        qs.query.alias_map = {}
+
+        explicit_filter = create_mock_filter("title", distinct=True)
+        filterset_class = create_mock_filterset_class(base_filters={"title": explicit_filter}, model=MagicMock())
+
+        result = _needs_distinct(qs, args={"title": "test"}, filterset_class=filterset_class)
+        assert result is True
+
+    def test_fallback_to_queryset_joins(self):
+        """When no filter needs distinct but QuerySet has M2M join, return True."""
+        from django.db.models.sql.datastructures import Join
+
+        from apibase.graphql.fields import _needs_distinct
+
+        # Create a proper Join-like object
+        join_field = create_mock_field(many_to_many=True, one_to_many=False)
+
+        class MockJoin(Join):
+            """Mock Join that overrides join_field."""
+
+            def __init__(self, join_field):
+                self._join_field = join_field
+
+            @property
+            def join_field(self):
+                return self._join_field
+
+        mock_join = MockJoin(join_field)
+
+        qs = MagicMock()
+        qs.query.alias_map = {"tags": mock_join}
+
+        # Filter doesn't need distinct by itself
+        simple_filter = create_mock_filter("is_active", distinct=False)
+        filterset_class = create_mock_filterset_class(base_filters={"is_active": simple_filter}, model=MagicMock())
+
+        simple_field = create_mock_field(many_to_many=False, one_to_many=False)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("apibase.graphql.fields.get_field_parts", lambda m, f: [simple_field])
+            result = _needs_distinct(qs, args={"is_active": True}, filterset_class=filterset_class)
+
+        assert result is True

--- a/devenv.nix
+++ b/devenv.nix
@@ -28,6 +28,10 @@
     pkgs.ruff
     pkgs.nixfmt-rfc-style
     pkgs.treefmt
+
+    # LSP / Type Checker
+    pkgs.basedpyright
+
   ];
 
   # mysqlclient ビルド用の環境変数
@@ -36,8 +40,8 @@
     MYSQLCLIENT_LDFLAGS = "-L${pkgs.libmysqlclient}/lib/mariadb -lmariadb";
   };
 
-  # pre-commit hooks
-  pre-commit.hooks = {
+  # git hooks
+  git-hooks.hooks = {
     ruff.enable = true;
     ruff-format.enable = true;
     nixfmt-rfc-style.enable = true;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["user.name <gmail@hdknr.com>"]
 python = "^3.9"
 graphene-django = "^2.10.1"
 django-cors-headers = "^3.3.0"
-djangorestframework-filters = {git = "https://github.com/philipn/django-rest-framework-filters.git"}
+djangorestframework-filters = { git = "https://github.com/philipn/django-rest-framework-filters.git" }
 django-filter = "^2.2.0"
 djangorestframework = "^3.11.0"
 gql = "^2.0.0"
@@ -25,34 +25,34 @@ ruff = "^0.9"
 mypy = "^1.0"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
 line-length = 119
 target-version = "py39"
 exclude = [
-    "migrations",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".tox",
-    "venv",
-    ".venv",
+  "migrations",
+  ".mypy_cache",
+  ".pytest_cache",
+  ".tox",
+  "venv",
+  ".venv",
 ]
 
 [tool.ruff.lint]
 select = [
-    "E",      # pycodestyle errors
-    "W",      # pycodestyle warnings
-    "F",      # pyflakes
-    "I",      # isort
-    "B",      # flake8-bugbear
-    "C4",     # flake8-comprehensions
-    "UP",     # pyupgrade
+  "E",  # pycodestyle errors
+  "W",  # pycodestyle warnings
+  "F",  # pyflakes
+  "I",  # isort
+  "B",  # flake8-bugbear
+  "C4", # flake8-comprehensions
+  "UP", # pyupgrade
 ]
 ignore = [
-    "E203",   # Whitespace before ':' (black compatibility)
-    "E501",   # Line too long (handled by formatter)
+  "E203", # Whitespace before ':' (black compatibility)
+  "E501", # Line too long (handled by formatter)
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -73,10 +73,4 @@ line-ending = "auto"
 [tool.mypy]
 python_version = "3.9"
 strict = true
-exclude = [
-    "migrations",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".tox",
-    "venv",
-]
+exclude = ["migrations", ".mypy_cache", ".pytest_cache", ".tox", "venv"]


### PR DESCRIPTION
## Summary

- NodeSet の `resolve_queryset()` で無条件に `distinct()` を適用していた箇所を、必要な場合のみ適用するよう最適化
- M2M/逆FK フィルタ使用時や `Filter(distinct=True)` 明示指定時のみ `distinct()` を適用
- `django-filter` の `get_field_parts()` を活用してフィールドパスを解析

## Background

`order_set` GraphQL クエリで、426k+ レコードに対して無条件 `distinct()` が適用されタイムアウトが発生していた。

**測定結果 (本番相当データ):**
- COUNT: 17.864s → 0.128s (約140倍改善)
- FETCH 15件: 224.626s → 6.939s (約32倍改善)

## Changes

### 新規追加
- `_filter_needs_distinct()`: フィルタ単位での distinct 判定
- `_queryset_has_duplicating_joins()`: QuerySet JOIN 解析 (フォールバック)
- `_needs_distinct()`: 総合判定関数

### distinct() 適用条件

| 条件 | distinct() | 理由 |
|------|-----------|------|
| フィルタなし | No | JOIN なし |
| 単純フィールド (`is_active=true`) | No | JOIN なし |
| FK フィルタ (`author_id=1`) | No | FK JOIN は重複しない |
| M2M フィルタ (`tags__name='x'`) | Yes | M2M JOIN は重複する |
| Reverse FK フィルタ | Yes | 逆参照 JOIN は重複する |
| `Filter(distinct=True)` | Yes | 明示指定 |
| method フィルタ (デフォルト) | No | パフォーマンス優先 |
| method フィルタ + `distinct=True` | Yes | 明示指定 |

## Test plan

- [x] 19個のユニットテスト追加 (`apibase/graphql/tests/test_distinct.py`)
- [x] 全テスト PASS (`poetry run pytest`)
- [x] `taihei-epm-server` で実際の order_set クエリの応答時間を確認
- [x] SQL ログで不要な DISTINCT が出ていないことを確認

## Notes

- Phase 1 のみ実装。Phase 2 (インデックス追加) と Phase 3 (`for_user()` distinct 再検討) は別途対応
- JOIN 判定は Django 内部 API (`query.alias_map`) に依存するため、バージョンアップ時に動作確認が必要
- 詳細な計画は `.claude/plan/order_set_graphql_timeout.md` を参照